### PR TITLE
fix(asu_degree_rfi): WS2-1070 handle rfi certs on degree detail pages

### DIFF
--- a/src/AsuDegreeRfiInterface.php
+++ b/src/AsuDegreeRfiInterface.php
@@ -10,4 +10,15 @@ interface AsuDegreeRfiInterface {
    * Caching duration for field data service calls.
    */
   const ASU_DEGREE_RFI_CACHE_LIFE = "+12 hours";
+
+  /**
+   * Path pattern used for Degree Detail pages.
+   *
+   * URL Pattern breakdown
+   * [program type]/majorinfo/[plan code]/[program type]/[cert or minor boolean]/[degree listing nid for breadcrumbs]
+   * More details captured on https://asudev.jira.com/browse/WS2-691
+   * We depart some from the Degree Search URL pattern found at
+   * https://docs.google.com/spreadsheets/d/1xHHT8v0EqBkKTasL0HM29lJdTbPcnCPso2AHkl_BPU4/edit#gid=0
+   */
+  const ASU_DEGREE_RFI_DETAIL_PATH_PATTERN = '/^\/(bachelors\-degrees|undergraduate\-certificates|graduate\-certificates|masters\-degrees-phds)\/majorinfo\/[A-Z]+\/(undergrad|graduate)\/(true|false)\/[0-9]+$/';
 }

--- a/src/Controller/AsuDegreePagesCreation.php
+++ b/src/Controller/AsuDegreePagesCreation.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\asu_degree_rfi\AsuDegreeRfiDegreeSearchClient;
+use Drupal\asu_degree_rfi\AsuDegreeRfiInterface;
 
 /**
  * Controller for the RFI component proxy to the Submit Handler Lambda.
@@ -36,9 +37,9 @@ class AsuDegreePagesCreation extends ControllerBase {
 
   public function load() {
     $path = \Drupal::service('path.current')->getPath();
-    $pattern_ulr = '/^\/(bachelors\-degrees|undergraduate\-certificates|graduate\-certificates|masters\-degrees-phds)\/majorinfo\/[A-Z]+\/(undergrad|graduate)\/(true|false)\/[0-9]+$/';
+    $pattern_url = AsuDegreeRfiInterface::ASU_DEGREE_RFI_DETAIL_PATH_PATTERN;
 
-    if (preg_match($pattern_ulr, $path)) {
+    if (preg_match($pattern_url, $path)) {
       $split_path = explode('/', $path);
       $node = Node::create(['type' => 'degree_detail_page']);
       $degree_query = $this->degreeSearchClient->getDegreeByAcadPlan($split_path[3]);

--- a/src/Plugin/Block/AsuDegreeRfiRfiBlock.php
+++ b/src/Plugin/Block/AsuDegreeRfiRfiBlock.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Cache\Cache;
 use Drupal\asu_degree_rfi\AsuDegreeRfiInterface;
+use Drupal\Component\Utility\UrlHelper;
 
 /**
  * ASU Degree RFI module RFI component block.
@@ -100,6 +101,21 @@ class AsuDegreeRfiRfiBlock extends BlockBase implements ContainerFactoryPluginIn
     // fallback value for the PoI in the props.
     $route_pgm_of_interest = \Drupal::service('asu_degree_rfi.helper_functions')->getRouteProgramOfInterest();
 
+    // Get path alias so we can look up if this is a certificate.
+    $path = \Drupal::service('path.current')->getPath();
+    $path_alias = \Drupal::service('path_alias.manager')->getAliasByPath($path);
+    $pattern_url = AsuDegreeRfiInterface::ASU_DEGREE_RFI_DETAIL_PATH_PATTERN;
+    // If path segment 5 is TRUE, it's a certificate. Set the default prop
+    // value to for that.
+    $isCertMinorDefault = null;
+    if (preg_match($pattern_url, $path_alias)) {
+      $split_path = explode('/', $path_alias);
+      if ($split_path[5] == "true") {
+        $isCertMinorDefault = TRUE;
+      }
+    }
+
+
     // RFI component blocks are deployed in 1 of 2 ways:
     // 1. RFI form component blocks are automatically created and configured
     //    with on-demand Degree detail page creation, with program of interest
@@ -127,7 +143,7 @@ class AsuDegreeRfiRfiBlock extends BlockBase implements ContainerFactoryPluginIn
     $props['areaOfInterest'] = $config['asu_degree_rfi_area_of_interest'] ? $config['asu_degree_rfi_area_of_interest'] : null;
     $props['programOfInterest'] = $config['asu_degree_rfi_program_of_interest'] ? $config['asu_degree_rfi_program_of_interest'] : $route_pgm_of_interest;
     $props['programOfInterestOptional'] = $config['asu_degree_rfi_p_of_i_optional'] ? $config['asu_degree_rfi_p_of_i_optional'] : null;
-    $props['isCertMinor'] = $config['asu_degree_rfi_is_cert_minor'] ? $config['asu_degree_rfi_is_cert_minor'] : null;
+    $props['isCertMinor'] = $config['asu_degree_rfi_is_cert_minor'] ? $config['asu_degree_rfi_is_cert_minor'] : $isCertMinorDefault;
     $props['country'] = $config['asu_degree_rfi_country'] ? $config['asu_degree_rfi_country'] : null;
     $props['stateProvince'] = $config['asu_degree_rfi_state_province'] ? $config['asu_degree_rfi_state_province'] : null;
     $props['successMsg'] = $config['asu_degree_rfi_success_msg']['value'] ? $config['asu_degree_rfi_success_msg']['value'] : null;


### PR DESCRIPTION
As noted on [WS2-1070](https://asudev.jira.com/browse/WS2-1070) there's an issue on certificate degree detail pages where the RFI doesn't get the isCertMinor prop automatically based on the degree.  I’ve addressed this issue by doing a lookup on the path for the degree detail page to determine if it’s a cert. If yes, then we set the isCertMinor default as true. This allows for override configurations to still occur.

Because I used the same URL pattern regex you wrote, @duarte-daniela , I added it to the AsuDegreeRfiInterface.php as `ASU_DEGREE_RFI_DETAIL_PATH_PATTERN` and I updated the page creation routine to use that constant. I've tested both the certificate settings fallback for the RFI and the Degree details creation routine, and both are in working order.