### PR TITLE
WS2-1216 - fix next step card props. see also WS2-1241

### DIFF
--- a/asu_degree_rfi.install
+++ b/asu_degree_rfi.install
@@ -89,6 +89,13 @@ function asu_degree_rfi_update_9005(&$sandbox) {
   _asu_degree_rfi_revert_all_module_config();
 }
 
+/**
+ * Revert all the module config.
+ */
+function asu_degree_rfi_update_9006(&$sandbox) {
+  _asu_degree_rfi_revert_all_module_config();
+}
+
 function _asu_degree_rfi_revert_all_module_config() {
   // Get this module name.
   $module = \Drupal::service('module_handler')

--- a/config/install/field.field.paragraph.degree_details_next_steps.field_degree_nxtstep_card_contnt.yml
+++ b/config/install/field.field.paragraph.degree_details_next_steps.field_degree_nxtstep_card_contnt.yml
@@ -12,7 +12,7 @@ field_name: field_degree_nxtstep_card_contnt
 entity_type: paragraph
 bundle: degree_details_next_steps
 label: 'Card content'
-description: ''
+description: 'Note: Next steps cards override the default Next steps cards (Learn more about our programs, Apply to program, and Visit our campus) from left to right. A total of three cards will always display. You can add up to three overrides. If you only want to override the final card, an easy way to do this is to add three cards, but only provide title overrides for the first two - which could be their original titles. The default content will be used for the first two.'
 required: false
 translatable: false
 default_value: {  }

--- a/src/Plugin/Block/AsuDegreeRfiDegreeDetailsBlock.php
+++ b/src/Plugin/Block/AsuDegreeRfiDegreeDetailsBlock.php
@@ -217,7 +217,16 @@ class AsuDegreeRfiDegreeDetailsBlock extends BlockBase {
       }
     }
     if (!empty($cards)) {
-      $nextSteps->cards = $cards;
+      // Exact nextSteps card names are required. Kinda wonky that the UI 
+      // is agnostic about these, but the component cares. We also convert
+      // to class for this layer of the props here.
+      $labelled_cards = new \stdClass();
+      if (isset($cards[0])) { $labelled_cards->learnMore = $cards[0]; }
+      if (isset($cards[1])) { $labelled_cards->apply = $cards[1]; }
+      if (isset($cards[2])) { $labelled_cards->visit = $cards[2]; }
+      // Note: Will always display 3 cards. If overrides aren't found, the
+      // remaining cards will display default contentss in the order above.
+      $nextSteps->cards = $labelled_cards;
       $props['nextSteps'] = $nextSteps;
     }
 


### PR DESCRIPTION
Fixing the issue Mitchell noted as blocking their site launch. Props for Next Steps cards are expected to have specific keys. I've updated the code to do this, and also added help text to explain the behavior expected and how to manage overrides in a flexible way via the UI. 💥 