### PR TITLE
fix php 8.1 deprecation of null value in explode()

### DIFF
--- a/src/Plugin/Block/AsuDegreeRfiDegreeListingBlock.php
+++ b/src/Plugin/Block/AsuDegreeRfiDegreeListingBlock.php
@@ -67,7 +67,8 @@ class AsuDegreeRfiDegreeListingBlock extends BlockBase {
     }
 
     $program = $node->field_degree_list_program->value;
-    $blacklist = array_map('trim', explode(",", $node->field_exclude_from_display->value));
+    $exclude_value = $node->field_exclude_from_display->value;
+    $blacklist = isset($exclude_value) ? array_map('trim', explode(",", $exclude_value)) : NULL;
     $certs_minors = $node->field_degree_list_certs_minors->value;
     $certs_minors_str = ($certs_minors) ? 'true' : 'false';
     $base_url = '';


### PR DESCRIPTION
This fixes a deprecation warning that cropped up after moving to Php 8.1. I found it while working on https://asudev.jira.com/browse/WS2-1464