### PR TITLE
WS2-1557: Add validation when Degree listing page does not exist

### DIFF
--- a/src/Controller/AsuDegreePagesCreation.php
+++ b/src/Controller/AsuDegreePagesCreation.php
@@ -9,6 +9,7 @@ use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\asu_degree_rfi\AsuDegreeRfiDegreeSearchClient;
 use Drupal\asu_degree_rfi\AsuDegreeRfiInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Controller for the RFI component proxy to the Submit Handler Lambda.
@@ -39,8 +40,15 @@ class AsuDegreePagesCreation extends ControllerBase {
     $path = \Drupal::service('path.current')->getPath();
     $pattern_url = AsuDegreeRfiInterface::ASU_DEGREE_RFI_DETAIL_PATH_PATTERN;
 
+    $node_storage = \Drupal::service('entity_type.manager')->getStorage('node');
+    $split_path = explode('/', $path);
+
+    if ($split_path[6] == null || $node_storage->loadByProperties(['nid' => $split_path[6], 'type' => 'degree_listing_page']) == null) {
+      $response = new Response(t('The Degree listing page with nid: @nid could not be found', ['@nid' => $split_path[6]]), 404);
+      return $response;
+    }
+
     if (preg_match($pattern_url, $path)) {
-      $split_path = explode('/', $path);
       $node = Node::create(['type' => 'degree_detail_page']);
       $degree_query = $this->degreeSearchClient->getDegreeByAcadPlan($split_path[3]);
       $title = isset($degree_query[0]['Descr100']) ? $degree_query[0]['Descr100'] : $split_path[3];

--- a/src/Controller/AsuDegreePagesCreation.php
+++ b/src/Controller/AsuDegreePagesCreation.php
@@ -43,9 +43,9 @@ class AsuDegreePagesCreation extends ControllerBase {
     $node_storage = \Drupal::service('entity_type.manager')->getStorage('node');
     $split_path = explode('/', $path);
 
-    if ($split_path[6] == null || $node_storage->loadByProperties(['nid' => $split_path[6], 'type' => 'degree_listing_page']) == null) {
-      $response = new Response(t('The Degree listing page with nid: @nid could not be found', ['@nid' => $split_path[6]]), 404);
-      return $response;
+    // Check if the Degree listing page exists.
+    if ($split_path[6] == NULL || $node_storage->loadByProperties(['nid' => $split_path[6], 'type' => 'degree_listing_page']) == NULL) {
+      return new Response(t('The Degree listing page with nid: @nid could not be found', ['@nid' => $split_path[6]]), 404);
     }
 
     if (preg_match($pattern_url, $path)) {


### PR DESCRIPTION
Ticket: https://asudev.jira.com/browse/WS2-1557

QA Steps: 

- Access the URL for a Degree Detail page by entering a non-existent nid of a Degree Listing page, for example: undergraduate-certificates/majorinfo/HSYSLMIN/undergrad/true/55555
- Verify that a 404 error page is displayed.
- Confirm that the error message includes the text "The Degree listing page with nid: [nid] does not exist".